### PR TITLE
Added cyberware listings, need to figure out way to add cyberware addons.

### DIFF
--- a/App/web/debug.log
+++ b/App/web/debug.log
@@ -1,1 +1,2 @@
 [0113/102132.159:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[0114/091539.902:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/App/web/src/layouts/BlogLayout/BlogLayout.js
+++ b/App/web/src/layouts/BlogLayout/BlogLayout.js
@@ -11,6 +11,10 @@ const BlogLayout = ({ children }) => {
             <li>
               <Link to={routes.about()}>About</Link>
             </li>
+            <li>
+              <Link to={routes.sheet()}>Sheet</Link>
+
+            </li>
           </ul>
         </nav>
       </header>

--- a/App/web/src/pages/SheetPage/SheetPage.js
+++ b/App/web/src/pages/SheetPage/SheetPage.js
@@ -4,12 +4,16 @@ import BlogLayout from '../../layouts/BlogLayout/BlogLayout'
   
 const SheetPage = () => {
   const [sheet, setSheet] = useState('')
-  const [parsed, setParsed] = useState({characters: {character: {metatype: '', alias: '', qualities: {quality: [{}]}}}})
+  const [parsed, setParsed] = useState({characters: {character: {metatype: '', alias: '', cyberwares: {cyberware: []}, qualities: {quality: [{}]}}}})
   const [qual, setQual] = useState([])
+  const [ware, setWare] = useState([])
+  const [spells, setSpells] = useState([])
+  const [powers, setPowers] = useState([])
 
   const handleParse = () => {
     setParsed(JSON.parse(sheet))
     setQual(parsed.characters.character.qualities.quality)
+    setWare(parsed.characters.character.cyberwares.cyberware)
     console.log(parsed)
   }
 
@@ -20,7 +24,11 @@ const SheetPage = () => {
     <p>Handle: {parsed.characters.character.alias}</p>
     <p>Metatype: {parsed.characters.character.metatype}</p>
     <p>Qualities: {qual.map((value, index) => {
-      return <li key={index}>{value.name} [{value.notes}]</li>})}</p>
+      return <li key={index}>{value.name} [{value.notes}]</li>
+    })}</p>
+    <p>Cyber/Bioware: {ware.map((value, index) => {
+      return <li key={index}>{value.name}</li>
+    })}</p>
     </BlogLayout>
 }
 


### PR DESCRIPTION
Current developmental issue: Addons are a separate set of children of each cyberware element, meaning that in current method of display, have to map through twice to get the addons, with only one return available.  Will research.